### PR TITLE
Use chefdk over chef-workstation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,9 @@ Policyfile.lock.json
 # TravisCI
 .travis/*
 !.travis/configs.tar.gz.enc
+
+# Dev Environment
+.gems/
+.envrc
+.rbenv-gemsets
+.ruby-version

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,15 +11,16 @@ services:
   - docker
 
 install:
-  - curl https://omnitruck.chef.io/install.sh | sudo bash -s -- -c current -P chef-workstation
+  - curl https://omnitruck.chef.io/install.sh | sudo bash -s -- -c current -P chefdk -v 3
   - chef exec bundle install
 
 env:
-  - SUITE=unit
-  - SUITE=default PLATFORM=ubuntu
-  - SUITE=default PLATFORM=centos
-  - SUITE=remove PLATFORM=ubuntu
-  - SUITE=remove PLATFORM=centos
+  matrix:
+    - SUITE=unit
+    - SUITE=default PLATFORM=ubuntu
+    - SUITE=default PLATFORM=centos
+    - SUITE=remove PLATFORM=ubuntu
+    - SUITE=remove PLATFORM=centos
 
 script:
   - if test "$SUITE" = "unit"; then chef exec delivery local all; fi

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 This file is used to list changes made in each version of the openvpn_okta cookbook.
 
+## 1.1.1 (2020-02-11)
+
+- Install `chefdk@v3` instead of `chef-workstation`.
+
 ## 1.0.1 (2019-01-22)
 
 - Remove 'rvm: system' from the TravisCI config

--- a/libraries/resource/openvpn_okta.rb
+++ b/libraries/resource/openvpn_okta.rb
@@ -93,7 +93,7 @@ class Chef
       #
       def disable_shim!
         srvr = find_resource(:openvpn_conf, 'server')
-        return unless srvr && srvr.config && srvr.config['plugin']
+        return unless srvr &.config && srvr.config['plugin']
 
         conf = config.to_h.dup
         conf.delete('plugin')

--- a/metadata.rb
+++ b/metadata.rb
@@ -6,7 +6,7 @@ maintainer_email 'sysadmin@socrata.com'
 license 'Apache-2.0'
 description 'Installs/configures the OpenVPN Okta plugin'
 long_description 'Installs/configures the OpenVPN Okta plugin'
-version '1.1.0'
+version '1.1.1'
 chef_version '>= 12.1'
 
 source_url 'https://github.com/socrata-cookbooks/openvpn_okta'


### PR DESCRIPTION
### Description

The travis job was failing due to the chef license not being accepted because chef-workstation no longer works for what we want.

### Issues Resolved

Building jobs on travis.

### Check List

- [x] New functionality includes tests
- [x] All tests pass
- [x] CHANGELOG has been updated
- [x] Version has been bumped in metadata
- [x] Commits have been squashed, as appropriate
- [ ] Commits include descriptive messages, subjects written in the imperative
